### PR TITLE
Increase timeout and retry for better user experience under slow network

### DIFF
--- a/app/src/main/java/com/murrayc/galaxyzoo/app/provider/HttpUtils.java
+++ b/app/src/main/java/com/murrayc/galaxyzoo/app/provider/HttpUtils.java
@@ -26,6 +26,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Base64;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
@@ -111,6 +112,7 @@ public final class HttpUtils {
         //so don't waste memory or storage caching it.
         //(We are downloading it to our own cache, of course.)
         request.setShouldCache(false);
+        request.setRetryPolicy(new DefaultRetryPolicy(30, 2, 1f));
 
         requestQueue.add(request);
 


### PR DESCRIPTION
I often couldn't open the image when my wifi is weak, and it turns out the default timeout is too short. So I increase it to 30 seconds as an enhancement.   