### PR TITLE
Fix classpath repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -13,5 +14,6 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
+        jcenter()
     }
 }


### PR DESCRIPTION
com.android.tools.build:gradle:2.2.3 is not in mavenCentral, but only in jcenter. You most likely haven't noticed this, because AndroidStudio silently defaults to jcenter.